### PR TITLE
Keep existing job id on retry

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,8 +10,9 @@ let package = Package(
         .library(name: "JobsRedis", targets: ["JobsRedis"])
     ],
     dependencies: [
-        .package(url: "https://github.com/hummingbird-project/swift-jobs.git", from: "1.0.0-beta.4"),
-        .package(url: "https://github.com/swift-server/RediStack.git", from: "1.4.0"),
+        // TODO: use a released version
+        .package(url: "https://github.com/thoven87/swift-jobs.git", branch: "update-job-on-retry"),
+        .package(url: "https://github.com/swift-server/RediStack.git", from: "1.6.2"),
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     ],
     dependencies: [
         // TODO: use a released version
-        .package(url: "https://github.com/thoven87/swift-jobs.git", branch: "update-job-on-retry"),
+        .package(url: "https://github.com/hummingbird-project/swift-jobs.git", branch: "main"),
         .package(url: "https://github.com/swift-server/RediStack.git", from: "1.6.2"),
     ],
     targets: [

--- a/Sources/JobsRedis/RedisJobQueue.swift
+++ b/Sources/JobsRedis/RedisJobQueue.swift
@@ -49,7 +49,7 @@ public final class RedisJobQueue: JobQueueDriver {
 
         public init(jobID: JobID, delayUntil: Date?) {
             self.jobID = .init()
-            self.delayUntil = Self.toMilliseconds(value: (delayUntil ?? Date.now).timeIntervalSince1970)
+            self.delayUntil = Self.toMilliseconds(value: delayUntil?.timeIntervalSince1970)
         }
 
         public init?(fromRESP value: RediStack.RESPValue) {

--- a/Sources/JobsRedis/RedisJobQueue.swift
+++ b/Sources/JobsRedis/RedisJobQueue.swift
@@ -159,13 +159,13 @@ public final class RedisJobQueue: JobQueueDriver {
         try await self.push(jobID: jobInstanceID, buffer: buffer, options: options)
         return jobInstanceID
     }
-    
+
     /// Helper for enqueuing jobs
     private func push(jobID: JobID, buffer: ByteBuffer, options: JobOptions) async throws {
         let pendingJobID = PendingJobID(jobID: jobID, delayUntil: options.delayUntil)
         try await self.addToQueue(pendingJobID, buffer: buffer)
     }
-    
+
     /// Retry job data onto queue
     /// - Parameters:
     ///   - id: JobID

--- a/Sources/JobsRedis/RedisJobQueue.swift
+++ b/Sources/JobsRedis/RedisJobQueue.swift
@@ -49,7 +49,7 @@ public final class RedisJobQueue: JobQueueDriver {
 
         public init(jobID: JobID, delayUntil: Date?) {
             self.jobID = .init()
-            self.delayUntil = Self.toMilliseconds(value: delayUntil?.timeIntervalSince1970)
+            self.delayUntil = Self.toMilliseconds(value: (delayUntil ?? Date.now).timeIntervalSince1970)
         }
 
         public init?(fromRESP value: RediStack.RESPValue) {
@@ -156,9 +156,26 @@ public final class RedisJobQueue: JobQueueDriver {
     /// - Returns: Job ID
     @discardableResult public func push(_ buffer: ByteBuffer, options: JobOptions) async throws -> JobID {
         let jobInstanceID = JobID()
-        let pendingJobID = PendingJobID(jobID: jobInstanceID, delayUntil: options.delayUntil)
-        try await self.addToQueue(pendingJobID, buffer: buffer)
+        try await self.push(jobID: jobInstanceID, buffer: buffer, options: options)
         return jobInstanceID
+    }
+    
+    /// Helper for enqueuing jobs
+    private func push(jobID: JobID, buffer: ByteBuffer, options: JobOptions) async throws {
+        let pendingJobID = PendingJobID(jobID: jobID, delayUntil: options.delayUntil)
+        try await self.addToQueue(pendingJobID, buffer: buffer)
+    }
+    
+    /// Retry job data onto queue
+    /// - Parameters:
+    ///   - id: JobID
+    ///   - buffer: Encoded Job data
+    ///   - options: JobOptions
+    /// - Returns: Bool
+    @discardableResult public func retry(_ id: JobID, buffer: NIOCore.ByteBuffer, options: Jobs.JobOptions) async throws -> Bool {
+        try await self.finished(jobId: id)
+        try await self.push(jobID: id, buffer: buffer, options: options)
+        return true
     }
 
     private func addToQueue(_ pendingJobID: PendingJobID, buffer: ByteBuffer) async throws {

--- a/Tests/JobsRedisTests/RedisJobsTests.swift
+++ b/Tests/JobsRedisTests/RedisJobsTests.swift
@@ -232,7 +232,7 @@ final class RedisJobsTests: XCTestCase {
 
     func testJobId() async throws {
         let job = RedisJobQueue.PendingJobID(jobID: .init(), delayUntil: nil)
-        XCTAssertGreaterThan(job.delayUntil, 0)
+        XCTAssertEqual(job.delayUntil, 0)
         XCTAssertEqual(job.isDelayed(), false)
         let futureDate = Date().addingTimeInterval(100)
         let delayedJob = RedisJobQueue.PendingJobID(jobID: .init(), delayUntil: futureDate)

--- a/Tests/JobsRedisTests/RedisJobsTests.swift
+++ b/Tests/JobsRedisTests/RedisJobsTests.swift
@@ -232,7 +232,7 @@ final class RedisJobsTests: XCTestCase {
 
     func testJobId() async throws {
         let job = RedisJobQueue.PendingJobID(jobID: .init(), delayUntil: nil)
-        XCTAssertEqual(job.delayUntil, 0)
+        XCTAssertGreaterThan(job.delayUntil, 0)
         XCTAssertEqual(job.isDelayed(), false)
         let futureDate = Date().addingTimeInterval(100)
         let delayedJob = RedisJobQueue.PendingJobID(jobID: .init(), delayUntil: futureDate)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+
+services:
+  redis:
+    image: redis/redis-stack-server:7.2.0-v15
+    ports:
+      - 6379:6379
+    healthcheck:
+      test: [ "CMD", "redis-cli", "--raw", "incr", "ping" ]
+    volumes:
+      - redis_data:/data
+
+volumes:
+  redis_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 
 services:
   redis:
-    image: redis/redis-stack-server:7.2.0-v15
+    image: redis:8.0-M03-alpine
     ports:
       - 6379:6379
     healthcheck:


### PR DESCRIPTION
* Assign a default value for delayed until
* Use retry func for trying jobs instead of assigning new job ID
* Added a helper function that's used in both retrying and queuing jobs
* Added docker compose file to help test with Podman or Docker