### PR TITLE
Conforming to the updated JobQueueDriver

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,8 @@ let package = Package(
         .library(name: "JobsRedis", targets: ["JobsRedis"])
     ],
     dependencies: [
-        .package(url: "https://github.com/hummingbird-project/swift-jobs.git", branch: "main"),
+        // TODO: use a released version
+        .package(url: "https://github.com/thoven87/swift-jobs.git", branch: "queue-name"),
         .package(url: "https://github.com/swift-server/RediStack.git", from: "1.6.2"),
     ],
     targets: [

--- a/Sources/JobsRedis/RedisJobQueue.swift
+++ b/Sources/JobsRedis/RedisJobQueue.swift
@@ -24,6 +24,10 @@ import struct Foundation.UUID
 
 /// Redis implementation of job queue driver
 public final class RedisJobQueue: JobQueueDriver {
+    
+    /// Queue to push jobs into
+    public let queueName: String
+    
     public struct JobID: Sendable, CustomStringConvertible, Equatable {
         let value: String
 
@@ -119,6 +123,7 @@ public final class RedisJobQueue: JobQueueDriver {
         self.configuration = configuration
         self.isStopped = .init(false)
         self.jobRegistry = .init()
+        self.queueName = configuration.queueKey.rawValue
     }
 
     ///  Cleanup job queues

--- a/Sources/JobsRedis/RedisJobQueue.swift
+++ b/Sources/JobsRedis/RedisJobQueue.swift
@@ -24,10 +24,10 @@ import struct Foundation.UUID
 
 /// Redis implementation of job queue driver
 public final class RedisJobQueue: JobQueueDriver {
-    
+
     /// Queue to push jobs into
     public let queueName: String
-    
+
     public struct JobID: Sendable, CustomStringConvertible, Equatable {
         let value: String
 


### PR DESCRIPTION
* Note: the Redis driver already had a queue name, this change will propagate the current queue name in the logger, middleware e.t.c