### PR TITLE
Resumable and cancellable jobs

### DIFF
--- a/Sources/JobsRedis/Configuration.swift
+++ b/Sources/JobsRedis/Configuration.swift
@@ -20,6 +20,7 @@ extension RedisJobQueue {
     public struct Configuration: Sendable {
         let queueKey: RedisKey
         let processingQueueKey: RedisKey
+        let pausedQueueKey: RedisKey
         let failedQueueKey: RedisKey
         let metadataKeyPrefix: String
         let pollTime: Duration
@@ -31,6 +32,7 @@ extension RedisJobQueue {
             self.queueKey = RedisKey("\(queueKey).pending")
             self.processingQueueKey = RedisKey("\(queueKey).processing")
             self.failedQueueKey = RedisKey("\(queueKey).failed")
+            self.pausedQueueKey = RedisKey("\(queueKey).paused")
             self.metadataKeyPrefix = "\(queueKey).metadata"
             self.pollTime = pollTime
         }

--- a/Tests/JobsRedisTests/RedisJobsTests.swift
+++ b/Tests/JobsRedisTests/RedisJobsTests.swift
@@ -490,11 +490,11 @@ final class RedisJobsTests: XCTestCase {
             )
 
             try await jobQueue.cancelJob(jobID: cancellable)
-            
+
             group.addTask {
                 try await serviceGroup.run()
             }
-            
+
             await self.fulfillment(of: [expectation], timeout: 5)
 
             await serviceGroup.triggerGracefulShutdown()


### PR DESCRIPTION
This PR introduces resumable and cancellable jobs.
It also fixes an issue where the job id that was returned from push was not the id that was stored in Redis