### PR TITLE
Rebuild script if they don't exist

### DIFF
--- a/Tests/JobsRedisTests/RedisJobsTests.swift
+++ b/Tests/JobsRedisTests/RedisJobsTests.swift
@@ -162,7 +162,7 @@ final class RedisJobsTests: XCTestCase {
         struct TestParameters: JobParameters {
             static let jobName = "testErrorRetryCount"
         }
-        let expectation = XCTestExpectation(description: "TestJob.execute was called", expectedFulfillmentCount: 4)
+        let expectation = XCTestExpectation(description: "TestJob.execute was called", expectedFulfillmentCount: 3)
         struct FailedError: Error {}
         try await self.testJobQueue(numWorkers: 1) { jobQueue in
             jobQueue.registerJob(

--- a/Tests/JobsRedisTests/RedisJobsTests.swift
+++ b/Tests/JobsRedisTests/RedisJobsTests.swift
@@ -433,6 +433,24 @@ final class RedisJobsTests: XCTestCase {
         }
     }
 
+    func testRebuildScripts() async throws {
+        struct TestParameters: JobParameters {
+            static let jobName = "testBasic"
+            let value: Int
+        }
+        let expectation = XCTestExpectation(description: "TestJob.execute was called", expectedFulfillmentCount: 1)
+        try await self.testJobQueue(numWorkers: 1) { jobQueue in
+            jobQueue.registerJob(parameters: TestParameters.self) { parameters, context in
+                context.logger.info("Parameters=\(parameters)")
+                _ = try await jobQueue.queue.redisConnectionPool.wrappedValue.scriptFlush(.sync).get()
+                expectation.fulfill()
+            }
+            try await jobQueue.push(TestParameters(value: 1))
+
+            await self.fulfillment(of: [expectation], timeout: 5)
+        }
+    }
+
     func testMetadata() async throws {
         let logger = Logger(label: "Jobs")
         let redis = try createRedisConnectionPool(logger: logger)


### PR DESCRIPTION
Given scripts are ephemeral and can be removed, we need to catch when a script doesn't exist and rebuild it